### PR TITLE
🚀 Simuliertes Kubernetes Deployment über GitHub Actions (Issue #10)

### DIFF
--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -1,0 +1,21 @@
+name: Simuliertes Kubernetes Deployment
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Simuliere Deployment
+        run: |
+          echo "👉 Anwendung würde jetzt mit folgenden Ressourcen deployed:"
+          echo "---"
+          cat k8s/deployment.yaml
+          echo "---"
+          cat k8s/service.yaml
+          echo "✅ Simulierter Kubernetes-Deployment erfolgreich."

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chat-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chat-app
+  template:
+    metadata:
+      labels:
+        app: chat-app
+    spec:
+      containers:
+        - name: chat-container
+          image: bjm1977ram/m324-chat-app-final:latest
+          ports:
+            - containerPort: 3000

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: chat-service
+spec:
+  type: ClusterIP
+  selector:
+    app: chat-app
+  ports:
+    - port: 3000
+      targetPort: 3000


### PR DESCRIPTION
Dieses Feature implementiert das simulierte Kubernetes Deployment gemäß Issue #10.

✅ Deployment-Manifest (`k8s/deployment.yaml`) beschreibt einen Pod mit dem Docker-Image `bjm1977ram/m324-chat-app-final`.
✅ Service-Manifest (`k8s/service.yaml`) stellt den Service auf Port 3000 bereit.
✅ GitHub Actions Workflow (`.github/workflows/k8s-deploy.yml`) simuliert die Anwendung des Deployments mit `echo`.

Hinweis: Es erfolgt kein echtes `kubectl apply`, sondern eine saubere Simulation.

Closes #10