### PR TITLE
📡 Uptime Kuma mit Telegram-Alarm eingerichtet (#12)

### DIFF
--- a/docs/uptime-kuma.md
+++ b/docs/uptime-kuma.md
@@ -1,0 +1,11 @@
+# Monitoring mit Uptime Kuma
+
+Dieses Projekt wird lokal über Uptime Kuma überwacht.
+
+- Uptime Kuma wurde via Docker lokal gestartet:
+  http://localhost:3001
+- 
+
+- Überwachte URL: `http://localhost:3000/healthcheck`
+- Erwarteter Statuscode: `200 OK`
+- Monitoring läuft lokal, da kein externer Kubernetes-Cluster verfügbar war.


### PR DESCRIPTION
    Docker-Container läuft lokal (louislam/uptime-kuma)

    Healthcheck-Monitor für m324-chat-app eingerichtet

    Telegram-Bot erfolgreich verbunden

    Testnachricht empfangen: „Mein Telegram Alarm M324 Testing“

✅ Closes #12